### PR TITLE
feat: cluster upgrade recommendation

### DIFF
--- a/pkg/Types.go
+++ b/pkg/Types.go
@@ -23,9 +23,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/xeipuuv/gojsonschema"
-	"strconv"
 )
 
 var SchemaErrorDetailsDisabled = true
@@ -58,6 +59,7 @@ type ValidationResult struct {
 	Deprecated             bool
 	LatestAPIVersion       string
 	IsVersionSupported     int
+	Resource               map[string]interface{} `json:"resource,omitempty"`
 }
 
 type SummarySchemaError struct {

--- a/pkg/Validator.go
+++ b/pkg/Validator.go
@@ -20,12 +20,13 @@ package pkg
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/devtron-labs/silver-surfer/pkg/log"
 	"github.com/getkin/kin-openapi/openapi3"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/yaml"
-	"sort"
-	"strings"
 )
 
 type kubeSpec struct {
@@ -64,6 +65,7 @@ func (ks *kubeSpec) ValidateJson(spec string) (ValidationResult, error) {
 func (ks *kubeSpec) ValidateObject(object map[string]interface{}) (ValidationResult, error) {
 	validationResult, err := ks.populateValidationResult(object)
 	validationResult.ValidatedAgainstSchema = true
+	validationResult.Resource = object
 	if err != nil {
 		return validationResult, err
 	}
@@ -88,10 +90,6 @@ func (ks *kubeSpec) ValidateObject(object map[string]interface{}) (ValidationRes
 		validationResult.ErrorsForOriginal = ves
 		validationResult.DeprecationForOriginal = des
 		validationResult.Deprecated = deprecated
-		//if original == latest {
-		//	validationResult.ErrorsForLatest = ves
-		//	validationResult.DeprecationForLatest = des
-		//}
 	} else if len(latest) == 0 { //if original and latest both are not present i.e; this has been completely removed eg psp
 		validationResult.Deleted = true
 		validationResult.IsVersionSupported = 2


### PR DESCRIPTION
# Add Migration File Generation Feature

## Description
This PR adds a new feature to generate migration files when Kubernetes API versions change between different Kubernetes versions. The feature helps users automatically generate updated manifests with the correct API versions while preserving all other configurations.

## Changes
- Added new command-line flags:
  - `--generate-migration-files`: Enable migration file generation
  - `--migration-output-dir`: Specify output directory for migration files (default: "migrations")
- Added `Resource` field to `ValidationResult` struct to store original resource data
- Implemented `MigrationFileGenerator` to handle migration file creation
- Modified validation process to preserve original resource data
- Added migration file generation logic to both file and cluster processing

## How it Works
1. When the `--generate-migration-files` flag is used, the tool:
   - Validates resources against both source and target Kubernetes versions
   - Identifies API version changes (e.g., `extensions/v1beta1` → `apps/v1`)
   - Generates migration files with updated API versions
   - Preserves all other resource configurations

2. Migration files are generated with names following the format:
   ```
   {namespace}-{name}-{kind}.yaml
   ```

3. Each migration file contains:
   - Updated API version
   - Original resource configuration
   - Properly formatted metadata

## Example Usage
```bash
./kubedd test-yamls/old-deployment.yaml \
  --generate-migration-files \
  --migration-output-dir ./migration-files \
  --source-kubernetes-version 1.30 \
  --target-kubernetes-version 1.31 \
  --source-schema-location ./schemas/1.30.json \
  --target-schema-location ./schemas/1.31.json
```

## Testing
- Tested with various resource types (Deployments, Ingress, Roles)
- Confirmed preservation of resource configurations
- Validated file naming and directory creation

## Benefits
- Automates the process of updating API versions
- Reduces manual work in Kubernetes version upgrades
- Preserves all resource configurations
- Provides clear migration path for users


## Related Issues
#13 
